### PR TITLE
Error fixes

### DIFF
--- a/example/mgdemo1.m
+++ b/example/mgdemo1.m
@@ -4,7 +4,7 @@
 
 % read video file into matlab
 % load mg_structure.mat;
-mg = mgread('pianist.mp4','pianist.wav','pianist.tsv');
+mg = mgread('pianist.avi','pianist.wav','pianist.tsv');
 % extract a segment from 10 seconds to 30 seconds from the mg
 mgseg = mgvideoreader(mg,'Extract',10,30);
 % map the same segment to audio,mocap dataset
@@ -48,19 +48,26 @@ mgvideoplot(mgsegmo,'Converted','Off');
 % plot the whole motion grams
 figure;
 subplot(211)
-gramx = medfilt2(mgsegmo.video.gram.gramx,[3,3]);
-gramx = mgsegmo.video.gram.gramx>0.3;
-gramx = mgsegmo.video.gram.gramx.*gramx;
+gramx = medfilt2(mgsegmo.video.gram.x,[3,3]);
+gramx = mgsegmo.video.gram.x>0.3;
+gramx = mgsegmo.video.gram.x.*gramx;
+%gramx = medfilt2(mgsegmo.video.gram.gramx,[3,3]);
+%gramx = mgsegmo.video.gram.gramx>0.3;
+%gramx = mgsegmo.video.gram.gramx.*gramx;
 
 imagesc(gramx)
-[~,n] = size(mgsegmo.video.gram.gramx);
+[~,n] = size(mgsegmo.video.gram.x);
+%[~,n] = size(mgsegmo.video.gram.gramx);
 set(gca,'XTick',[0:2*mgsegmo.video.obj.FrameRate:n]);
 set(gca,'XTickLabel',[0:2*mgsegmo.video.obj.FrameRate:n]/mgsegmo.video.obj.FrameRate+mgsegmo.video.starttime);
 title('horizontal gram');
 subplot(212)
-gramy = medfilt2(mgsegmo.video.gram.gramy,[3,3]);
-gramy = mgsegmo.video.gram.gramy>0.4;
-gramy = mgsegmo.video.gram.gramy.*gramy;
+gramy = medfilt2(mgsegmo.video.gram.y,[3,3]);
+gramy = mgsegmo.video.gram.y>0.4;
+gramy = mgsegmo.video.gram.y.*gramy;
+%gramy = medfilt2(mgsegmo.video.gram.gramy,[3,3]);
+%gramy = mgsegmo.video.gram.gramy>0.4;
+%gramy = mgsegmo.video.gram.gramy.*gramy;
 imagesc(gramy);
 set(gca,'YTick',[0:2*mgsegmo.video.obj.FrameRate:n]);
 set(gca,'YTickLabel',[0:2*mgsegmo.video.obj.FrameRate:n]/mgsegmo.video.obj.FrameRate+mgsegmo.video.starttime);

--- a/example/mgdemo2.m
+++ b/example/mgdemo2.m
@@ -2,7 +2,7 @@
 % this example shows you how to analysis multiple objects, as the original
 % video recordings are too large.We need to resample the video recordings
 % first. 
-mg = mgread('dance.mp4');
+mg = mgread('dance.avi');
 % extract a temporal segment from the video
 ts = 5;
 te = 25;
@@ -49,14 +49,18 @@ xlabel('seconds')
 ylabel('magnitude')
 
 %%
-gramx = medfilt2(mgsammo.video.gram.gramx,[3,3]);
-gramx = mgsammo.video.gram.gramx>0.3;
-gramx = mgsammo.video.gram.gramx.*gramx;
+gramx = medfilt2(mgsammo.video.gram.x,[3,3]);
+gramx = mgsammo.video.gram.x>0.3;
+gramx = mgsammo.video.gram.x.*gramx;
+%gramx = medfilt2(mgsammo.video.gram.gramx,[3,3]);
+%gramx = mgsammo.video.gram.gramx>0.3;
+%gramx = mgsammo.video.gram.gramx.*gramx;
 figure;
 subplot(211)
 imagesc(gramx)
 fr = mgsammo.video.obj.FrameRate;
-[~,n] = size(mgsammo.video.gram.gramx);
+[~,n] = size(mgsammo.video.gram.x);
+%[~,n] = size(mgsammo.video.gram.gramx);
 set(gca,'XTick',[0:2*fr:mgsammo.video.nframe]);
 set(gca,'XTickLabel',[fr*...
     mgsammo.video.starttime:...
@@ -64,9 +68,12 @@ set(gca,'XTickLabel',[fr*...
     mgsammo.video.endtime*fr]...
     /fr);
 title('horizontal gram');
-gramy = medfilt2(mgsammo.video.gram.gramy,[3,3]);
-gramy = mgsammo.video.gram.gramy>0.4;
-gramy = mgsammo.video.gram.gramy.*gramy;
+gramy = medfilt2(mgsammo.video.gram.y,[3,3]);
+gramy = mgsammo.video.gram.y>0.4;
+gramy = mgsammo.video.gram.y.*gramy;
+%gramy = medfilt2(mgsammo.video.gram.gramy,[3,3]);
+%gramy = mgsammo.video.gram.gramy>0.4;
+%gramy = mgsammo.video.gram.gramy.*gramy;
 subplot(212)
 imagesc(gramy);
 set(gca,'YTick',[0:2*fr:mgsammo.video.nframe]);

--- a/source-code/mgmotion.m
+++ b/source-code/mgmotion.m
@@ -17,7 +17,9 @@ function mg = mgmotion(f,varargin)
 % mg = mgmotion(filename,'Diff',starttime,endtime,'Regular',0.3);
 % mg = mgmotion(filename,'OpticalFlow',starttime,'Binary',0.2);
 % mg = mgmotion(mg,'OpticalFlow');
-%
+% mg = mgmotion(mg, ...., 'color');
+% mg = mgmotion(mg, ...., 'convert');
+
 % input:
 % filename: the name of the video file
 % mg: instead of filename, uses a musical gestures data structure
@@ -39,205 +41,70 @@ frameInterval = 1;
 ii = 0;
 l = length(varargin);
 
-if ischar(f)
-    if l < 1
-        method = 'Diff'; % default;
-        starttime = 0;
-        mg = mgvideoreader(f);
-        endtime = mg.video.endtime;
-        filterflag = 0;
-    elseif l == 1
-        if strcmpi(varargin{1},'Diff') || strcmpi(varargin{1},'OpticalFlow')
-            method = varargin{1};
-            starttime = 0;
-            mg = mgvideoreader(f);
-            endtime = mg.video.endtime;
-            filterflag = 0;
-        else
-            error('please specify a method for motion estimation, Diff or OpticalFlow.');
-        end
-    elseif l == 2
-        if strcmpi(varargin{1},'Diff') || strcmpi(varargin{1},'OpticalFlow')
-            method = varargin{1};
-            if isnumeric(varargin{2})
-                starttime = varargin{2};
-                mg = mgvideoreader(f,'Extract',starttime);
-                endtime = mg.video.endtime;
-                filterflag = 0;
-            elseif ischar(varargin{2})&& (strcmpi(varargin{2},'Regular') || strcmpi(varargin{2},'Binary'))
-                starttime = 0;
-                mg = mgvideoreader(f);
-                endtime = mg.video.endtime;
-                filtertype = varargin{2};
-                thresh = 0.1; % default;
-                filterflag = 1;
-            else
-                error('Please specify a filter type, Regular or Binary');
-            end
-        else
-            error('Please specify a method for the motion estimation, Diff or OpticalFlow');
-        end
-    elseif l == 3
-        if strcmpi(varargin{1},'Diff') || strcmpi(varargin{1},'OpticalFlow')
-            method = varargin{1};
-            if isnumeric(varargin{2})  && isnumeric(varargin{3})
-                starttime = varargin{2};
-                endtime = varargin{3};
-                mg = mgvideoreader(f,'Extract',starttime,endtime);
-                filterflag = 0;
-            elseif isnumeric(varargin{2}) && ischar(varargin{3})
-                starttime = varargin{2};
-                mg = mgvideoreader(f,'Extract',starttime);
-                endtime = mg.video.endtime;
-                filtertype = varargin{3};
-                filterflag = 1;
-                thresh = 0.1; % default;
-            elseif ischar(varargin{2})
-                starttime = 0;
-                mg = mgvideoreader(f);
-                endtime = mg.video.endtime;
-                filtertype = varargin{2};
-                thresh = varargin{3};
-                filterflag = 1;
-            else
-                error('Please input proper parameters.');
-            end
-        else
-            error('Please specify a method for motion estimation, Diff or OpticalFlow.');
-        end
-    elseif l == 4
-        if strcmpi(varargin{1},'Diff') || strcmpi(varargin{1},'OpticalFlow')
-            method = varargin{1};
-            if isnumeric(varargin{2}) && isnumeric(varargin{3}) && ismember(lower(varargin{4}),lower({'Binary','Regular'}))
-                starttime = varargin{2};
-                endtime = varargin{3};
-                mg = mgvideoreader(f,'Extract',starttime,endtime);
-                filtertype = varargin{4};
-                thresh = 0.1;
-                filterflag = 1;
-            elseif isnumeric(varargin{2}) && ischar(varargin{3}) && isnumeric(varargin{4})
-                starttime = varargin{2};
-                mg = mgvideoreader(f,'Extract',starttime);
-                endtime = mg.video.endtime;
-                filtertype = varargin{3};
-                thresh = varargin{4};
-                filterflag = 1;
-            else
-                error('Please input proper parameters.');
-            end
-        else
-            error('Please specify a method for motion estimation, Diff or OpticalFlow');
-        end
-    elseif l == 5
-        if ismember(lower(varargin{1}),lower({'Diff','OpticalFlow'}))
-            method = varargin{1};
-            if isnumeric(varargin{2}) && isnumeric(varargin{3}) && ismember(lower(varargin{4}),lower({'Binary','Regular','Blob'})) && isnumeric(varargin{5})
-                starttime = varargin{2};
-                endtime = varargin{3};
-                mg = mgvideoreader(f,'Extract',starttime,endtime);
-                filtertype = varargin{4};
-                filterflag = 1;
-                thresh = varargin{5};
-            else
-                error('Please input proper parameters.');
-            end
-        else
-            error('Please specify a method for motion estimation, Diff or OpticalFlow');
-        end
-    end
+
+cmd = [];
+
+if(ischar(f))
+    disp('input is a file');
+    mg = mgvideoreader(f);
+    cmd.inputType = 'file';
 elseif isstruct(f) && isfield(f,'video')
+    disp('input is mg struct');
     mg = f;
-    if l < 1
-        method = 'Diff';
-        starttime = mg.video.starttime;
-        endtime = mg.video.endtime;
-        filterflag = 0;
-    elseif l == 1
-        if ismember(lower(varargin{1}),lower({'Diff','OpticalFlow'}))
-            method = varargin{1};
-            starttime = mg.video.starttime;
-            endtime = mg.video.endtime;
-            filterflag = 0;
-        else
-            error('Please specify a method for motion estimation.');
-        end
-    elseif l == 2
-        if ismember(lower(varargin{1}),lower({'Diff','OpticalFlow'})) && isnumeric(varargin{2})
-            method = varargin{1};
-            starttime = varargin{2};
-            endtime = mg.video.endtime;
-            filterflag = 0;
-        elseif ismember(lower(varargin{1}),lower({'Diff','OpticalFlow'})) && ismember(lower(varargin{2}),lower({'Binary','Regular'}))
-            method = varargin{1};
-            filtertype = varargin{2};
-            filterflag = 1;
-            starttime = mg.video.starttime;
-            endtime = mg.video.endtime;
-            thresh = 0.1; % default;
-        else
-            error('Please specify a method for motion estimation, Diff or OpticalFlow');
-        end
-    elseif l == 3
-        if ismember(lower(varargin{1}),lower({'Diff','OpticalFlow'}))
-            method = varargin{1};
-            if isnumeric(varargin{2}) && isnumeric(varargin{3})
-                starttime = varargin{2};
-                endtime = varargin{3};
-                filterflag = 0;
-            elseif isnumeric(varargin{2}) && ismember(lower(varargin{3}),lower({'Binary','Regular'}))
-                starttime = varargin{2};
-                endtime = mg.video.endtime;
-                filtertype = varargin{3};
-                thresh = 0.1;
-                filterflag = 1;
-            elseif ischar(varargin{2}) && isnumeric(varargin{3})
-                starttime = mg.video.starttime;
-                endtime = mg.video.endtime;
-                filtertype = varargin{2};
-                filterflag = 1;
-                thresh = varargin{3};
-            else
-                error('Please input proper parameters')
+    cmd.inputType = 'struct';
+end
+
+cmd.method = 'Diff';
+cmd.starttime = mg.video.starttime;
+cmd.endtime = mg.video.endtime;
+cmd.filterflag = 0;
+cmd.filtertype = [];
+cmd.thresh = 0.1;
+cmd.color = 'off';
+cmd.convert = 'off';
+
+for argi = 1:l
+    if( ischar(varargin{argi}))   
+        if(strcmpi(varargin{argi},'Diff') || strcmpi(varargin{argi},'OpticalFlow') )
+            disp('method specified in argument');
+            
+            cmd.method = varargin{argi};
+            
+            if(argi + 1 <= l && isnumeric(varargin{argi + 1}))
+                disp('starttime specified in argument');
+                cmd.starttime = varargin{argi+1};
+                if(argi + 2 <= l &&isnumeric(varargin{argi + 2})) 
+                    disp('stoptime specified in argument');
+                    cmd.endtime = varargin{argi+2};
+                end
             end
-        else
-            error('Please specify a method for motion estimation');
-        end
-    elseif l == 4
-        if ismember(lower(varargin{1}),lower({'Diff','OpticalFlow'}))
-            method = varargin{1};
-            if isnumeric(varargin{2}) && isnumeric(varargin{3}) && ismember(lower(varargin{4}),lower({'Binary','Regular'}))
-                starttime = varargin{2};
-                endtime = varargin{3};
-                filtertype = varargin{4};
-                thresh = 0.1;
-                filterflag = 1;
-            elseif isnumeric(varargin{2}) && ischar(varargin{3}) && isnumeric(varargin{4})
-                starttime = varargin{2};
-                endtime = mg.video.endtime;
-                filtertype = varargin{3};
-                thresh = varargin{4};
-                filterflag = 1;
-            else
-                error('Please input proper parameters');
+            
+        elseif (strcmpi(varargin{argi},'Regular') || strcmpi(varargin{argi},'Binary') ) 
+            disp('filtertype specified in argument');
+            cmd.filtertype = varargin{argi};
+            if(argi + 1 <= l &&  isnumeric(varargin{argi + 1}))
+                disp('thresh specified in argument');
+                cmd.thresh = varargin{argi+1};
             end
-        else
-            error('Please specify a method for motion estimation');
+        elseif (strcmpi(varargin{argi},'Color'))
+            disp('color mode on is specified in argument');
+            cmd.color = 'on'
+        elseif (strcmpi(varargin{argi},'Convert'))
+            disp('Convert mode on is specified in argument');
+            cmd.convert = 'on'
         end
-    elseif l == 5
-        if ischar(varargin{1}) && ischar(varargin{4})
-            method = varargin{1};
-            starttime = varargin{2};
-            endtime = varargin{3};
-            filtertype = varargin{4};
-            thresh = varargin{5};
-            filterflag = 1;
-        else
-            error('Please check the input parameters');
-        end
-    else
-        error('Wrong number of input parameters');
     end
 end
+
+
+method = cmd.method;
+starttime = cmd.starttime;
+endtime = cmd.endtime;
+endtime = cmd.endtime;
+filterflag = cmd.filterflag;
+filtertype = cmd.filtertype;
+thresh = cmd.thresh;
+
 
 mg.video.method = method;
 mg.video.gram.y = [];
@@ -252,25 +119,37 @@ mg.video.endtime = endtime;
 % hblob = vision.BlobAnalysis;
 % hblob.AreaOutputPort = true;
 
-if isfield(mg.video,'mode') && isfield(mg.video.mode,'color')
-    if strcmpi(mg.video.mode.color,'on')
-        colorflag = true;
+if(strcmpi(cmd.color, 'on'))
+    colorflag = true;
+else
+    if (isfield(mg.video,'mode') && isfield(mg.video.mode,'color') ) 
+        if strcmpi(mg.video.mode.color,'on') 
+            colorflag = true;
+        else
+            colorflag = false;
+        end
     else
         colorflag = false;
     end
-else
-    colorflag = false;
 end
 
-if isfield(mg.video,'mode') && isfield(mg.video.mode,'convert')
-    if strcmpi(mg.video.mode.convert,'on')
-        convertflag = true;
+
+if(strcmpi(cmd.convert, 'on'))
+    convertflag = true'
+else
+    if (isfield (mg.video,'mode') && isfield(mg.video.mode,'convert'))
+        if strcmpi(mg.video.mode.convert,'on')
+            convertflag = true;
+        else
+            convertflag = false;
+        end
     else
         convertflag = false;
     end
-else
-    convertflag = false;
 end
+
+
+
 
 if strcmpi(method,'Diff')
     mg.video.obj.CurrentTime = starttime;
@@ -284,13 +163,15 @@ if strcmpi(method,'Diff')
     v = VideoWriter(newfile);
     v.FrameRate = mg.video.obj.FrameRate;
     ind = 1;
-    numf = mg.video.obj.FrameRate*(endtime-starttime)-1;
+    %numf = mg.video.obj.FrameRate*(endtime-starttime)-1;
+    numf = mg.video.obj.FrameRate*(endtime-starttime); %eg. for 1 second at 25fps,  25*(0-1) = 25 
     open(v);
     if colorflag == true
         h = waitbar(0,'Processing video...');
         while hasFrame(mg.video.obj)
             %progmeter(ind,numf);
-            waitbar(mg.video.obj.CurrentTime/mg.video.obj.Duration,h);
+            %waitbar(mg.video.obj.CurrentTime/mg.video.obj.Duration,h);
+            waitbar(mg.video.obj.CurrentTime/mg.video.endtime,h);
             pfr = readFrame(mg.video.obj);
             ii = ii + 1;
             if mod(ii,frameInterval) == 0
@@ -322,6 +203,9 @@ if strcmpi(method,'Diff')
                 writeVideo(v,diff);
                 fr = pfr;
                 ind = ind + 1;
+                if(ind > numf)
+                    break;
+                end
             end
         end
         close(h);
@@ -333,7 +217,8 @@ if strcmpi(method,'Diff')
         h = waitbar(0,'Processing video...');
         while hasFrame(mg.video.obj)
             %progmeter(ind,numf);
-            waitbar(mg.video.obj.CurrentTime/mg.video.obj.Duration,h);
+            %waitbar(mg.video.obj.CurrentTime/mg.video.obj.Duration,h);
+            waitbar(mg.video.obj.CurrentTime/mg.video.endtime,h);
             pfr = rgb2gray(readFrame(mg.video.obj));
             ii = ii + 1;
             if mod(ii,frameInterval) == 0
@@ -365,6 +250,9 @@ if strcmpi(method,'Diff')
                 writeVideo(v,diff);
                 fr = pfr;
                 ind = ind + 1;
+                if(ind > numf)
+                    break;
+                end
             end
         end
         close(h);

--- a/source-code/mgmotion.m
+++ b/source-code/mgmotion.m
@@ -451,6 +451,7 @@ elseif strcmpi(method,'OpticalFlow')
     close(v);
     disp(' ');
     disp(['The motion video is created with name ',newfile]);
+    mg.video.nframe = v.FrameCount;
     
     %    figure,subplot(211),plot(mg.video.qom)
     %    title('Quantity of motion by opticalflow');

--- a/source-code/mgmotion.m
+++ b/source-code/mgmotion.m
@@ -19,7 +19,7 @@ function mg = mgmotion(f,varargin)
 % mg = mgmotion(mg,'OpticalFlow');
 % mg = mgmotion(mg, ...., 'color');
 % mg = mgmotion(mg, ...., 'convert');
-
+% mg = mgmotion(mg, ...., 'interval', 10);
 % input:
 % filename: the name of the video file
 % mg: instead of filename, uses a musical gestures data structure
@@ -62,7 +62,7 @@ cmd.filtertype = [];
 cmd.thresh = 0.1;
 cmd.color = 'off';
 cmd.convert = 'off';
-
+cmd.frameInterval = 1;
 for argi = 1:l
     if( ischar(varargin{argi}))   
         if(strcmpi(varargin{argi},'Diff') || strcmpi(varargin{argi},'OpticalFlow') )
@@ -92,6 +92,10 @@ for argi = 1:l
         elseif (strcmpi(varargin{argi},'Convert'))
             disp('Convert mode on is specified in argument');
             cmd.convert = 'on'
+        elseif (strcmpi(varargin{argi},'Interval'))
+            if(argi + 1 <= l &&  isnumeric(varargin{argi + 1}))
+                cmd.frameInterval = varargin{argi+1};
+            end
         end
     end
 end
@@ -104,7 +108,7 @@ endtime = cmd.endtime;
 filterflag = cmd.filterflag;
 filtertype = cmd.filtertype;
 thresh = cmd.thresh;
-
+frameInterval = cmd.frameInterval;
 
 mg.video.method = method;
 mg.video.gram.y = [];

--- a/source-code/mgmotionaverage.m
+++ b/source-code/mgmotionaverage.m
@@ -54,6 +54,7 @@ if ischar(f)
         i = i + 1;
     end
 elseif isstruct(f) && isfield(f,'video')
+    mg = f;
     if l == 1
         starttime = mg.video.starttime;
         endtime = mg.video.endtime;

--- a/source-code/mgvideoplot.m
+++ b/source-code/mgvideoplot.m
@@ -138,4 +138,9 @@ while hasFrame(mgmotion.video.obj)
         pause(1/mgmotion.video.obj.FrameRate);
     end
    i = i + 1;
+  
+   if(  (round((i/30) * mgmotion.mocap.freq) + 1) > mgmotion.mocap.nFrames)
+    break;
+   end
+   
 end


### PR DESCRIPTION
**fixed: problem saving color images from mgmotionaverage.** 

'mg' was previously not pointing to f.

**fixed: problem with missing nframe in 'OpticalFlow' option in mgmotion.**

nframe value previously was set only for 'DIff' condition and not for 'OpticalFlow'. Add

`mg.video.nframe = v.FrameCount`

at line after

`disp(['The motion video is created with name ',newfile]);`

inside the 'OpticalFlow' condition.

**fixed: issue in "plots the whole motion grams".** 

Previously the frame loop inside mgvideoplot never ended even after processing all the frames.

use the condition after incrementing 'i' to detect end frame and break the loop.

```
if( (round((i/30) * mgmotion.mocap.freq) + 1) > mgmotion.mocap.nFrames)
break;
end
```

**fixed: problem in demo file with missing/undeclared variables gramx and gramy.** 

mgmotion outputs data to 

`mg.video.gram.x`

 instead of 

`mg.video.gram.gramx`


**fixed: mgmotion output video length fixed in mgmotion**
output video length determinded by
`numf = mg.video.obj.FrameRate*(endtime-starttime)-1` 
one less of a frame. So for 25 fps for 1 second, it created 24 frames only. Now fixed with
`numf = mg.video.obj.FrameRate*(endtime-starttime)` 

**fixed: endtime previously did not work in mgmotion**
the video length could be trimmed using the starttime untile the end of the video length but the endtime parameter did not work. Now fixed 

**enhancement: mgmotion input parameter now supports _color_ and _convert_ and _interval_ for frame interval**
enhancement: mgmotion input parameters does not need to be in specific order. **
Reordering parameters are supported, however options like starttime and endtime followed must be followed by the parameter for method, and the thresh parameter should follow the filtertype parameter

**enhancement: mgmotion argument handling routine cleaned up**
less code and more flexibility to add or modify input argument options